### PR TITLE
Adds support for Jekyll-formatted header

### DIFF
--- a/test/jekyllstyle.md
+++ b/test/jekyllstyle.md
@@ -1,0 +1,5 @@
+---
+title: This is Jekyll-style
+---
+
+Here is the content.

--- a/test/yamlhead.test.js
+++ b/test/yamlhead.test.js
@@ -60,5 +60,13 @@ suite('YAMLHead', function () {
       done();
     });
   });
+
+  test('Handles Jekyll files.', function (done) {
+    yamlhead(__dirname + '/jekyllstyle.md', function (err, yaml, data) {
+      assert.equal(yaml.title, 'This is Jekyll-style');
+      assert.equal(data, 'Here is the content.');
+      done();
+    });
+  });
 });
 

--- a/yamlhead.js
+++ b/yamlhead.js
@@ -46,6 +46,10 @@ YAMLHead.prototype.write = function(data) {
   this.data += data;
   // Check for YAML header separator.
   if (!this.header) {
+    // Handle Jekyll-style triple dashes at the beginning of the file
+    if (this.data.substr(0, 4) === "---\n") {
+      this.data = this.data.substr(4);
+    }
     var pos = this.data.search(this._sep);
     if (pos !== -1) {
       try {


### PR DESCRIPTION
Triple-dash line at the beginning of the file.

As documented in the [front-matter section](http://jekyllrb.com/docs/frontmatter/) of the Jekyll
docs.
