### PR TITLE
Updated to work better on Windows

### DIFF
--- a/yamlhead.js
+++ b/yamlhead.js
@@ -47,9 +47,7 @@ YAMLHead.prototype.write = function(data) {
   // Check for YAML header separator.
   if (!this.header) {
     // Handle Jekyll-style triple dashes at the beginning of the file
-    if (this.data.substr(0, 4) === "---\n") {
-      this.data = this.data.substr(4);
-    }
+    this.data = this.data.replace(/^---\s*[\r\n]+/, '');
     var pos = this.data.search(this._sep);
     if (pos !== -1) {
       try {


### PR DESCRIPTION
Currently, yamlhead chokes on the initial "---" found in jekyll templates if they were created on Windows, since the newline character can be '\r\n'.

While I was at it, I updated the code to allow the jekyll leading "---" to have trailing whitespace as well.